### PR TITLE
add option to refresh user authorization

### DIFF
--- a/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
+++ b/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
@@ -28,6 +28,13 @@ class MagpieAuthenticator(Authenticator):
     You may also optionally choose to set an `authorization_url` which is a URL that can be used to check whether the
     user logged in to Magpie has permission to access jupyterhub:
      - c.MagpieAuthenticator.authorization_url = "http://twitcher:8000/ows/verify/jupyterhub"
+
+    If `authorization_url` is set, then setting `enable_auth_state` will enable jupyterhub to store the user's magpie
+    cookies. This will allow the `refresh_user` method to periodically check whether the user is still authorized and
+    will attempt to log them out of jupyterhub if not.
+
+    If `authorization_url` and `enable_auth_state` are set, then you may also be interested in setting the
+    `refresh_pre_spawn` and `auth_refresh_age` variables. See the jupyterhub documentation for more details.
     """
     default_provider = "ziggurat"
     magpie_url = Unicode(
@@ -73,4 +80,20 @@ class MagpieAuthenticator(Authenticator):
                                    expires=cookie.expires,
                                    path=cookie.path,
                                    secure=cookie.secure)
+            if self.enable_auth_state:
+                return {"name": data['username'], "auth_state": {"magpie_cookies": response.cookies.get_dict()}}
             return data['username']
+
+    async def refresh_user(self, user, handler=None):
+        if not (self.authorization_url and self.enable_auth_state):
+            # MagpieAuthenticator is not configured to re-check user authorization
+            return True
+        auth_state = await user.get_auth_state()
+        cookies = auth_state.get("magpie_cookies")
+        if cookies:
+            auth_response = requests.get(self.authorization_url, cookies=cookies)
+            if auth_response.ok:
+                return True
+        if handler:
+            handler.clear_login_cookie()
+        return False

--- a/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
+++ b/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
@@ -82,7 +82,8 @@ class MagpieAuthenticator(Authenticator):
                                    secure=cookie.secure)
             if self.enable_auth_state:
                 return {"name": data['username'], "auth_state": {"magpie_cookies": response.cookies.get_dict()}}
-            return data['username']
+            else:
+                return data['username']
 
     async def refresh_user(self, user, handler=None):
         if not (self.authorization_url and self.enable_auth_state):


### PR DESCRIPTION
Implements the `refresh_user` method which can be used to check if a user still has authorization to access jupyterhub after they have logged in. 

It does so by storing the (encrypted) cookie from magpie at login and periodically checking in with magpie/twitcher to see whether user still has permission to access jupyterhub.

To enable this feature: 

- set the `enable_auth_state` variable to `True`
- set the `authorization_url` (eg: `"http://twitcher:8000/ows/verify/jupyterhub"`)

To check before the user spawns a new jupyterlab container set `refresh_pre_spawn` variable to `True`

To change how often the `refresh_user` method is triggered, set the `auth_refresh_age` to a positive integer (default = 300) in seconds

Resolves #2