### PR TITLE
Do not normalize username

### DIFF
--- a/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
+++ b/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
@@ -58,6 +58,16 @@ class MagpieAuthenticator(Authenticator):
             ('/logout', MagpieLogoutHandler)
         ]
 
+    def normalize_username(self, username):
+        """
+        Do not normalize username but still apply username_map if set.
+
+        This ensures that mounted directories on the host machine are discovered properly
+        since we expect the username to match the username set by Magpie.
+        """
+        username = self.username_map.get(username, username)
+        return username
+
     async def authenticate(self, handler, data):
         signin_url = self.magpie_url.rstrip('/') + '/signin'
 


### PR DESCRIPTION
This ensures that mounted directories on the host machine are discovered properly since we expect the username to match the username set by Magpie. 

See https://github.com/bird-house/birdhouse-deploy/pull/396 for full motivation