### PR TITLE
ensure refresh_user still works before user state has been persisted to db

### DIFF
--- a/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
+++ b/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
@@ -86,10 +86,11 @@ class MagpieAuthenticator(Authenticator):
                 return data['username']
 
     async def refresh_user(self, user, handler=None):
-        if not (self.authorization_url and self.enable_auth_state):
-            # MagpieAuthenticator is not configured to re-check user authorization
-            return True
         auth_state = await user.get_auth_state()
+        if auth_state is None:
+            # MagpieAuthenticator is not configured to re-check user authorization or the auth state
+            # has not been persisted to the database yet.
+            return True
         cookies = auth_state.get("magpie_cookies")
         if cookies:
             auth_response = requests.get(self.authorization_url, cookies=cookies)


### PR DESCRIPTION
When a user logs in, the `refresh_user` seems to be called before the user's `auth_state` is persisted to the database. 

We assumed that this could not happen in this order so we assumed that `auth_state` could not be None when `refresh_user` was called. This assumption seems to be false. 

To fix this, we should use [a pattern suggested by the documentation](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#using-auth-state) to simply check whether the auth_state is None directly.

Note, this has been tested in the birdhouse stack and I can confirm that the auth_state does eventually (later in the log-in chain) get persisted to the database and is used to refresh the user as expected.