### PR TITLE
fix edge case where auth state is left behind in an updated instance

### DIFF
--- a/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
+++ b/jupyterhub_magpie_authenticator/jupyterhub_magpie_authenticator.py
@@ -96,7 +96,7 @@ class MagpieAuthenticator(Authenticator):
 
     async def refresh_user(self, user, handler=None):
         auth_state = await user.get_auth_state()
-        if auth_state is None:
+        if auth_state is None or not (self.authorization_url and self.enable_auth_state):
             # MagpieAuthenticator is not configured to re-check user authorization or the auth state
             # has not been persisted to the database yet.
             return True


### PR DESCRIPTION
If the `authorization_url` and `enable_auth_state` values were previously set, then later one or both are unset, jupyterhub is restarted, and the database is not cleared, there will be an `auth_state` present for users who previously logged in stored in the database.

In this case, jupyterhub will still attempt to update the `auth_state` with a now invalid `authorization_url`. This adds additional checks to ensure that this will not attempt to update the `auth_state` with invalid settings.
