### PR TITLE
Disable Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "enabled": false,
   "extends": [
     "config:base"
   ]


### PR DESCRIPTION
This should disable Renovate until we know for sure we can safely uninstall it from Ouranosinc.

Credit to @mishaschwartz for delving into the docs to find this.